### PR TITLE
Remove inline JS and add noopener to links

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@
 	<link rel="stylesheet" href="https://glenn-sorrentino.github.io/design-system/css/style.css">
 	<link rel="stylesheet" href="css/style.css">
 
-	<script src="https://code.jquery.com/jquery-latest.min.js"></script>
-	<script src="https://glenn-sorrentino.github.io/design-system/js/main.js"></script>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-latest.min.js"></script>
+	<script type="text/javascript" src="https://glenn-sorrentino.github.io/design-system/js/main.js"></script>
+	<script type="text/javascript" src="javascript/copyright.js"></script>
 </head>
 
 <body class="glow">
@@ -40,7 +41,7 @@
 					<li><a href="#email">Email</a></li>
 					<li><a href="#vpn">VPN</a></li>
 					<li><a href="#anon">Anonymity</a></li>
-					<li><a class="btn primaryBtn" href="https://github.com/glenn-sorrentino/normalsecurity.com" target="_blank">Contribute</a></li>
+					<li><a class="btn primaryBtn" href="https://github.com/glenn-sorrentino/normalsecurity.com" target="_blank" rel="nooopener noreferrer">Contribute</a></li>
 				</ul>
 			</nav>
 			<nav class="staged">
@@ -57,7 +58,7 @@
 					<li><a href="#email">Email</a></li>
 					<li><a href="#vpn">VPN</a></li>
 					<li><a href="#anon">Anonymity</a></li>
-					<li><a class="btn primaryBtn" href="https://github.com/glenn-sorrentino/normal-security" target="_blank">Contribute</a></li>
+					<li><a class="btn primaryBtn" href="https://github.com/glenn-sorrentino/normal-security" target="_blank" rel="nooopener noreferrer">Contribute</a></li>
 				</ul>
 			</nav>
 		</div>
@@ -86,45 +87,45 @@
 			<div class="description">
 				<p class="parent">Call &amp; Text</p>
 				<div class="icon signal"></div>
-				<h3><a href="https://signal.org" target="_blank">Signal</a></h3>
+				<h3><a href="https://signal.org" target="_blank" rel="nooopener noreferrer">Signal</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 					<p class="badge">🎉 Open Source</p>
 					<p class="badge">✌️Non-Profit</p>
 				</div>
 				<p>Signal is a secure texting, calling, and video chat app that doesn't collect any information about you. It's widely considered to be the safest option for communication, and even <a
-						href="https://www.militarytimes.com/flashpoints/2020/01/23/deployed-82nd-airborne-unit-told-to-use-these-encrypted-messaging-apps-on-government-cellphones/" target="_blank">the Army recommends Signal</a> for their troops to use in
+						href="https://www.militarytimes.com/flashpoints/2020/01/23/deployed-82nd-airborne-unit-told-to-use-these-encrypted-messaging-apps-on-government-cellphones/" target="_blank" rel="nooopener noreferrer">the Army recommends Signal</a> for their troops to use in
 					countries where surveillance is pervasive.</p>
-				<p><a href="https://www.businessinsider.com/what-is-signal" target="_blank">Business Insider</a> writes about some of Signal's core features.</p>
+				<p><a href="https://www.businessinsider.com/what-is-signal" target="_blank" rel="nooopener noreferrer">Business Insider</a> writes about some of Signal's core features.</p>
 			</div>
 		</div>
 		<div id="password" class="contentItem centeredContent blockContent">
 			<div class="description">
 				<p class="parent">Passwords</p>
 				<div class="icon bit"></div>
-				<h3><a href="https://bitwarden.com" target="_blank">Bitwarden</a></h3>
+				<h3><a href="https://bitwarden.com" target="_blank" rel="nooopener noreferrer">Bitwarden</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 					<p class="badge">🎉 Open Source</p>
 				</div>
 				<p>Bitwarden is a secure cloud password manager. It has a browser extension and an app, making logging into websites and apps easy. Its free option works on different platforms, and paid features include being able to use it for both password
 					management and two-factor authentication.</p>
-				<p>In <a href="https://mshelton.medium.com/bitwarden-for-beginners-74cf93679457" target="_blank">Bitwarden for Beginners</a>, <a href="https://mshelton.medium.com/" target="_blank">Martin Shelton</a> walks through how to get started.</p>
+				<p>In <a href="https://mshelton.medium.com/bitwarden-for-beginners-74cf93679457" target="_blank" rel="nooopener noreferrer">Bitwarden for Beginners</a>, <a href="https://mshelton.medium.com/" target="_blank" rel="nooopener noreferrer">Martin Shelton</a> walks through how to get started.</p>
 			</div>
 		</div>
 		<div id="web" class="contentItem centeredContent blockContent">
 			<div class="description">
 				<p class="parent">Internet</p>
 				<div class="icon ff"></div>
-				<h3><a href="https://firefox.com" target="_blank">Firefox</a></h3>
+				<h3><a href="https://firefox.com" target="_blank" rel="nooopener noreferrer">Firefox</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 					<p class="badge">🎉 Open Source</p>
 					<p class="badge">✌️Non-Profit</p>
 				</div>
-				<p>Firefox is an internet browser that has built-in features like <a href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" target="_blank">tracker blocking</a>, <a
-						href="https://support.mozilla.org/en-US/kb/https-only-prefs" target="_blank">HTTPS-only mode</a>, <a href="https://support.mozilla.org/en-US/kb/firefox-dns-over-https" target="_blank">DNS privacy</a>, and allows you to <a
-						href="https://support.mozilla.org/en-US/kb/share-data-mozilla-help-improve-firefox" target="_blank">opt-out of data collection</a> from the organization.</p>
+				<p>Firefox is an internet browser that has built-in features like <a href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop" target="_blank" rel="nooopener noreferrer">tracker blocking</a>, <a
+						href="https://support.mozilla.org/en-US/kb/https-only-prefs" target="_blank" rel="nooopener noreferrer">HTTPS-only mode</a>, <a href="https://support.mozilla.org/en-US/kb/firefox-dns-over-https" target="_blank" rel="nooopener noreferrer">DNS privacy</a>, and allows you to <a
+						href="https://support.mozilla.org/en-US/kb/share-data-mozilla-help-improve-firefox" target="_blank" rel="nooopener noreferrer">opt-out of data collection</a> from the organization.</p>
 			</div>
 		</div>
 		<div class="contentItem centeredContent contentRow">
@@ -133,19 +134,19 @@
 				<div class="contentItem blockContent">
 					<div class="description">
 						<div class="icon ublock"></div>
-						<h4><a href="https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/" target="_blank">uBlock Origin</a></h4>
+						<h4><a href="https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/" target="_blank" rel="nooopener noreferrer">uBlock Origin</a></h4>
 						<div class="badgeContainer">
 							<p class="badge">🎁 Free</p>
 							<p class="badge">🎉 Open Source</p>
 						</div>
 						<p>Ad and tracker blocking. Available in Chrome, Firefox, Edge.</p>
-						<p>Read Wirecutter's review of <a href="https://www.nytimes.com/wirecutter/reviews/our-favorite-ad-blockers-and-browser-extensions-to-protect-privacy/" target="_blank">more ad and tracker blockers</a>.</p>
+						<p>Read Wirecutter's review of <a href="https://www.nytimes.com/wirecutter/reviews/our-favorite-ad-blockers-and-browser-extensions-to-protect-privacy/" target="_blank" rel="nooopener noreferrer">more ad and tracker blockers</a>.</p>
 					</div>
 				</div>
 				<div class="contentItem blockContent">
 					<div class="description">
 						<div class="icon https"></div>
-						<h4><a href="https://www.eff.org/de/https-everywhere" target="_blank">HTTPS Everywhere</a></h4>
+						<h4><a href="https://www.eff.org/de/https-everywhere" target="_blank" rel="nooopener noreferrer">HTTPS Everywhere</a></h4>
 						<div class="badgeContainer">
 							<p class="badge">🎁 Free</p>
 							<p class="badge">🎉 Open Source</p>
@@ -157,7 +158,7 @@
 				<div class="contentItem blockContent">
 					<div class="description">
 						<div class="icon bit"></div>
-						<h4><a href="https://bitwarden.com" target="_blank">Bitwarden</a></h4>
+						<h4><a href="https://bitwarden.com" target="_blank" rel="nooopener noreferrer">Bitwarden</a></h4>
 						<div class="badgeContainer">
 							<p class="badge">🎁 Free</p>
 							<p class="badge">🎉 Open Source</p>
@@ -171,19 +172,19 @@
 			<div class="description">
 				<p class="parent">Two-Factor</p>
 				<div class="icon authy"></div>
-				<h3><a href="https://authy.com" target="_blank">Authy</a></h3>
+				<h3><a href="https://authy.com" target="_blank" rel="nooopener noreferrer">Authy</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 				</div>
 				<p>A simple two-factor app that backs up codes to the cloud so that when you change devices you'll never get locked out of your accounts.</p>
-				<p>Check out <a href="https://www.nytimes.com/wirecutter/reviews/best-two-factor-authentication-app/" target="_blank">Wirecutter's guide for two-factor apps</a>.</p>
+				<p>Check out <a href="https://www.nytimes.com/wirecutter/reviews/best-two-factor-authentication-app/" target="_blank" rel="nooopener noreferrer">Wirecutter's guide for two-factor apps</a>.</p>
 			</div>
 		</div>
 		<div id="files" class="contentItem centeredContent blockContent">
 			<div class="description">
 				<p class="parent">Files</p>
 				<div class="icon keybase"></div>
-				<h3><a href="https://keybase.io" target="_blank">Keybase</a></h3>
+				<h3><a href="https://keybase.io" target="_blank" rel="nooopener noreferrer">Keybase</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 				</div>
@@ -194,19 +195,19 @@
 			<div class="description">
 				<p class="parent">Notes</p>
 				<div class="icon stdnotes"></div>
-				<h3><a href="https://standardnotes.org" target="_blank">Standard Notes</a></h3>
+				<h3><a href="https://standardnotes.org" target="_blank" rel="nooopener noreferrer">Standard Notes</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 					<p class="badge">🎉 Open Source</p>
 				</div>
-				<p>Standard Notes is a <a href="https://standardnotes.org/help/2/has-standard-notes-completed-a-third-party-security-audit" target="_blank">secure</a> note-taking app. It syncs across devices and has apps for all platforms.</p>
+				<p>Standard Notes is a <a href="https://standardnotes.org/help/2/has-standard-notes-completed-a-third-party-security-audit" target="_blank" rel="nooopener noreferrer">secure</a> note-taking app. It syncs across devices and has apps for all platforms.</p>
 			</div>
 		</div>
 		<div id="email" class="contentItem centeredContent blockContent">
 			<div class="description">
 				<p class="parent">Email</p>
 				<div class="icon proton"></div>
-				<h3><a href="https://protonmail.com" target="_blank">Protonmail</a></h3>
+				<h3><a href="https://protonmail.com" target="_blank" rel="nooopener noreferrer">Protonmail</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 					<p class="badge">🎉 Open Source</p>
@@ -218,27 +219,27 @@
 			<div class="description">
 				<p class="parent">VPN</p>
 				<div class="icon vpn"></div>
-				<h3><a href="https://protonvpn.com" target="_blank">ProtonVPN</a></h3>
+				<h3><a href="https://protonvpn.com" target="_blank" rel="nooopener noreferrer">ProtonVPN</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 					<p class="badge">🎉 Open Source</p>
 				</div>
 				<p>ProtonVPN is a virtual private network (VPN) service provider operated by the makers of ProtonMail. VPNs change your IP address - an identifying number associated with your internet connection - and secures your internet traffic, making
 					your device's physical location and data connection private.</p>
-				<p>Freedom of the Press Foundation has written an <a href="https://freedom.press/training/choosing-a-vpn/" target="_blank">in-depth guide to choosing a VPN</a>.</p>
+				<p>Freedom of the Press Foundation has written an <a href="https://freedom.press/training/choosing-a-vpn/" target="_blank" rel="nooopener noreferrer">in-depth guide to choosing a VPN</a>.</p>
 			</div>
 		</div>
 		<div id="anon" class="contentItem centeredContent blockContent">
 			<div class="description">
 				<p class="parent">Anonymity</p>
 				<div class="icon tor"></div>
-				<h3><a href="https://torproject.org" target="_blank">Tor Browser</a></h3>
+				<h3><a href="https://torproject.org" target="_blank" rel="nooopener noreferrer">Tor Browser</a></h3>
 				<div class="badgeContainer">
 					<p class="badge">🎁 Free</p>
 					<p class="badge">🎉 Open Source</p>
 					<p class="badge">✌️Non-Profit</p>
 				</div>
-				<p>Using Tor Browser is similar to browsing the internet using a VPN, but powered by technology <a href="https://www.torproject.org/about/history/" target="_blank">originally designed by the US Navy to protect against surveillance on the
+				<p>Using Tor Browser is similar to browsing the internet using a VPN, but powered by technology <a href="https://www.torproject.org/about/history/" target="_blank" rel="nooopener noreferrer">originally designed by the US Navy to protect against surveillance on the
 						internet</a>. Now Tor is used by journacontents, activists, students, researchers, and everyday people who don't want their online behavior being logged and cataloged by governments and corporations.</p>
 			</div>
 		</div>
@@ -250,21 +251,21 @@
 			<div class="contentItem blockContent">
 				<div class="description">
 					<div class="icon eff"></div>
-					<h3><a href="https://ssd.eff.org/en" target="_blank">EFF</a></h3>
+					<h3><a href="https://ssd.eff.org/en" target="_blank" rel="nooopener noreferrer">EFF</a></h3>
 					<p>Surveillance Self-Defense: Tips, Tools, and How-tos for Safer Online Communications.</p>
 				</div>
 			</div>
 			<div class="contentItem blockContent">
 				<div class="description">
 					<div class="icon fpf"></div>
-					<h3><a href="https://freedom.press/training/" target="_blank">Freedom of the Press Foundation</a></h3>
+					<h3><a href="https://freedom.press/training/" target="_blank" rel="nooopener noreferrer">Freedom of the Press Foundation</a></h3>
 					<p>Digital security training for news organizations, freelance and citizen journacontents, and other at-risk groups.</p>
 				</div>
 			</div>
 			<div class="contentItem blockContent">
 				<div class="description">
 					<div class="icon cr"></div>
-					<h3><a href="https://www.consumerreports.org/digital-security/online-security-and-privacy-guide/" target="_blank">Consumer Reports</a></h3>
+					<h3><a href="https://www.consumerreports.org/digital-security/online-security-and-privacy-guide/" target="_blank" rel="nooopener noreferrer">Consumer Reports</a></h3>
 					<p>Easy-to-follow tips to protect you and your family.</p>
 				</div>
 			</div>
@@ -273,21 +274,21 @@
 			<div class="contentItem blockContent">
 				<div class="description">
 					<div class="icon times"></div>
-					<h3><a href="https://www.nytimes.com/guides/privacy-project/how-to-protect-your-digital-privacy" target="_blank">New York Times</a></h3>
+					<h3><a href="https://www.nytimes.com/guides/privacy-project/how-to-protect-your-digital-privacy" target="_blank" rel="nooopener noreferrer">New York Times</a></h3>
 					<p>How to protect your digital privacy.</p>
 				</div>
 			</div>
 			<div class="contentItem blockContent">
 				<div class="description">
 					<div class="icon pt"></div>
-					<h3><a href="https://privacytools.io/" target="_blank">PrivacyTools</a></h3>
+					<h3><a href="https://privacytools.io/" target="_blank" rel="nooopener noreferrer">PrivacyTools</a></h3>
 					<p>PrivacyTools provides services, tools, and knowledge to protect your privacy against global mass surveillance.</p>
 				</div>
 			</div>
 			<div class="contentItem blockContent">
 				<div class="description">
 					<div class="icon calyx"></div>
-					<h3><a href="https://calyxinstitute.org/docs" target="_blank">Calyx Institute</a></h3>
+					<h3><a href="https://calyxinstitute.org/docs" target="_blank" rel="nooopener noreferrer">Calyx Institute</a></h3>
 					<p>How-tos from the Calyx Institute.</p>
 				</div>
 			</div>
@@ -297,9 +298,8 @@
 	<!-- FOOTER -->
 
 	<footer class="wrapper clearfix">
-		<p>This work is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC BY NC 4.0 license</a>.<br>&copy; <script>
-				document.write(new Date().getFullYear());
-			</script> <a href="https://glennsorrentino.com" target="_blank">Glenn Sorrentino</a>. Created with the <a href="https://glenn-sorrentino.github.io/design-system" target="_blank">Simple Design System</a>.</p>
+		<p>This work is licensed under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="nooopener noreferrer">CC BY NC 4.0 license</a>.<br>&copy; <span id="date">?</span>
+			<a href="https://glennsorrentino.com" target="_blank" rel="nooopener noreferrer">Glenn Sorrentino</a>. Created with the <a href="https://glenn-sorrentino.github.io/design-system" target="_blank" rel="nooopener noreferrer">Simple Design System</a>.</p>
 		<p>🛡&nbsp;zs1lqjvywdg308kxrn6x8xduqm5j6j8fg28tertjtayfj8hwm0gvk5gyh3jd07p5w5fe7r56xjr2gj</p>
 	</footer>
 

--- a/javascript/copyright.js
+++ b/javascript/copyright.js
@@ -1,0 +1,5 @@
+function copyright() {
+  document.getElementById("date").innerHTML = new Date().getFullYear().toString()
+}
+
+$(document).ready(copyright);


### PR DESCRIPTION
Moves the copyright JS into an external file rather than inline (allows for a stronger Content Security Policy). 

Adds `rel='nooopener noreferrer'` to href links to clear reverse tabnabbing warning by security auditing tools such as OWASP ZAP.